### PR TITLE
[feat] Release 2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,33 @@
+<a name="2.1.0"></a>
+# [2.1.0] - 2024-07-29
+
+## Features
+- Attachments upload dialog
+- Highlight text message cell content for links/phone numbers
+- Update minimum iOS deployment target to 15
+- Display thumbnail previews for selected attachment videos/images.
+- Utilize Swift's Quicklook framework to view documents
+
+## Bug Fixes
+- Prefill prechat survey with customer data
+- Rotation bug on iOS15
+- Incorrect attachment size displayed for single attachment
+- append UTType.movie for all videos
+- fix MessageGroupView preview
+
+## Dependencies
+- Update CxoneChatSDK to 2.1.0
+
 <a name="2.0.1"></a>
 # [2.0.1] - 2024-07-11
 
-### Chore
-- update SDK to 2.0.1
+## Dependencies
+- Update CxoneChatSDK to 2.0.1
 
 <a name="2.0.0"></a>
 # [2.0.0] - 2024-06-13
 
-### Features
+## Features
 - Add Live chat mode
 - Minimum iOS deployment target set to iOS 14.0
 - Add localized strings to sdk package
@@ -17,7 +37,7 @@
 - Handle sent message via `onThreadUpdated(_:)`
 - Privacy Manifest
 
-### Bug Fixes
+## Bug Fixes
 - Rotation bug on iOS15
 - Incorrect attachment size displayed for single attachment
 - append UTType.movie for all videos
@@ -26,27 +46,27 @@
 - remove validation for Prechat survey
 
 <a name="1.3.3"></a>
-## [1.3.3] - 2024-05-15
+# [1.3.3] - 2024-05-15
 
-### Bug Fixes
+## Bug Fixes
 - make assignedAgent optional for the event
 
 <a name="1.3.2"></a>
-## [1.3.2] - 2024-03-21
+# [1.3.2] - 2024-03-21
 
-### Features
+## Features
 - Create SDK's UserDefaults + Better Keychain handling
 
 <a name="1.3.1"></a>
-## [1.3.1] - 2024-03-12
+# [1.3.1] - 2024-03-12
 
-### Features
+## Features
 - Privacy Manifest
 
 <a name="1.3.0"></a>
-## [1.3.0] - 2024-03-12
+# [1.3.0] - 2024-03-12
 
-### Bug Fixes
+## Bug Fixes
 - Fixed deeplink format
 - Correct CreateOrUpdateVisitor URL
 - Resolve issue with submodules for GitHub Actions
@@ -70,7 +90,7 @@
 - Handle different thread correctly
 - Fix issue when multiple messages with matching ids are received
 
-### Features
+## Features
 - add login error state in case of unreachable API
 - Add basic validation for brandId and channelId
 - Login with Amazon SDK update + fixed Launch screen storyboard
@@ -88,9 +108,9 @@
 - Correct handling of welcome message
 
 <a name="1.2.0"></a>
-## [1.2.0] - 2023-09-22
+# [1.2.0] - 2023-09-22
 
-### Bug Fixes
+## Bug Fixes
 - working Login preview
 - Remove reporting viewPage for chat related
 - duplicate SFSymbol image to SwiftUI + remove conversion from UIImage to Image
@@ -105,7 +125,7 @@
 - Correct title when enter thread detail
 - Fixed problem in hexString where wrong color was being created.
 
-### Features
+## Features
 - change open Chat button background color
 - Login with Amazon SDK update + fixed Launch screen storyboard
 - Update version to 1.2.0
@@ -123,15 +143,15 @@
 - Analytics Usage in E-shop
 
 <a name="1.1.1"></a>
-## [1.1.1] - 2023-07-10
+# [1.1.1] - 2023-07-10
 
-### Features
+## Features
 - Update decoding of ThreadRecoveredEvent
 
 <a name="1.1.0"></a>
-## [1.1.0] - 2023-06-23
+# [1.1.0] - 2023-06-23
 
-### Bug Fixes
+## Bug Fixes
 - Remove not supported fields in ReceivedThreadRecoveredPostbackData
 - Return message with attachments
 - use correct EventDataType for loadThreadData and messageSeenByCustomer
@@ -140,7 +160,8 @@
 - use Docker image for changelog GitHub action
 - use correct UUID for thread
 - access file stored in Documents
-### Features
+
+## Features
 - SwiftLint explicit init
 - Event Type Unification
 - use Codable only in valid cases + Encodable in test target
@@ -156,15 +177,15 @@
 - Add case studies + change jazzy output file
 
 <a name="1.0.1"></a>
-## [1.0.1] - 2023-03-14
+# [1.0.1] - 2023-03-14
 
-### Features
+## Features
 - notify about close connection
 
 <a name="1.0.0"></a>
-## 1.0.0 - 2023-01-31
+# 1.0.0 - 2023-01-31
 
-### Features
+## Features
 - Logging PoC
 - Error handling
 - Connection
@@ -225,7 +246,9 @@
     - failure
   - typing start/end
 
-[Unreleased]: https://github.com/nice-devone/nice-cxone-mobile-ui-ios/compare/2.0.0...HEAD
+[Unreleased]: https://github.com/nice-devone/nice-cxone-mobile-ui-ios/compare/2.1.0...HEAD
+[2.1.0]: https://github.com/nice-devone/nice-cxone-mobile-ui-ios/compare/2.0.1...2.1.0
+[2.0.1]: https://github.com/nice-devone/nice-cxone-mobile-ui-ios/compare/2.0.0...2.0.1
 [2.0.0]: https://github.com/nice-devone/nice-cxone-mobile-ui-ios/compare/1.3.3...2.0.0
 [1.3.3]: https://github.com/nice-devone/nice-cxone-mobile-ui-ios/compare/1.3.2...1.3.3
 [1.3.2]: https://github.com/nice-devone/nice-cxone-mobile-ui-ios/compare/1.3.1...1.3.2

--- a/Package.resolved
+++ b/Package.resolved
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/nice-devone/nice-cxone-mobile-sdk-ios.git",
       "state" : {
-        "revision" : "817895c5ebca3e19063c1841c0cee36d9ecc6570",
-        "version" : "2.0.1"
+        "revision" : "7903c360d2e173ecc9a77d1829e30ce24412e65e",
+        "version" : "2.1.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -19,7 +19,7 @@ import PackageDescription
 let package = Package(
     name: "CXoneChatUI",
     defaultLocalization: "en",
-    platforms: [.iOS(.v14)],
+    platforms: [.iOS(.v15)],
     products: [
         .library(
             name: "CXoneChatUI",
@@ -30,7 +30,7 @@ let package = Package(
         .package(url: "https://github.com/onevcat/Kingfisher.git", from: "7.0.0"),
         .package(url: "https://github.com/siteline/swiftui-introspect", from: "0.8.0"),
         .package(url: "https://github.com/wxxsw/GSPlayer.git", from: "0.2.25"),
-        .package(url: "https://github.com/nice-devone/nice-cxone-mobile-sdk-ios.git", from: "2.0.1")
+        .package(url: "https://github.com/nice-devone/nice-cxone-mobile-sdk-ios.git", from: "2.1.0")
     ],
     targets: [
         .target(

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The CXoneChatUI module provides a default implementation of a Chat User Interfac
 
 ## Requirements
 
-- iOS 14.0+
+- iOS 15.0+
 - Swift 5+
 
 

--- a/Sources/Domain/Model/AttachmentRestrictions.swift
+++ b/Sources/Domain/Model/AttachmentRestrictions.swift
@@ -1,0 +1,41 @@
+//
+// Copyright (c) 2021-2024. NICE Ltd. All rights reserved.
+//
+// Licensed under the NICE License;
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    https://github.com/nice-devone/nice-cxone-mobile-ui-ios/blob/main/LICENSE
+//
+// TO THE EXTENT PERMITTED BY APPLICABLE LAW, THE CXONE MOBILE SDK IS PROVIDED ON
+// AN “AS IS” BASIS. NICE HEREBY DISCLAIMS ALL WARRANTIES AND CONDITIONS, EXPRESS
+// OR IMPLIED, INCLUDING (WITHOUT LIMITATION) WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, AND TITLE.
+//
+
+import CXoneChatSDK
+
+struct AttachmentRestrictions {
+    
+    /// Maximum size of allowed uploads in megabytes (1024x1024).
+    let allowedFileSize: Int32
+    
+    /// Allowed file mime types.
+    let allowedTypes: [String]
+    
+    /// True if attachment uploads are allowed.  If false, no uploads are allowed.
+    let areAttachmentsEnabled: Bool
+}
+
+// MARK: - Mappers
+
+extension AttachmentRestrictions {
+
+    static func map(from entity: FileRestrictions) -> AttachmentRestrictions {
+        AttachmentRestrictions(
+            allowedFileSize: entity.allowedFileSize,
+            allowedTypes: entity.allowedFileTypes.map(\.mimeType),
+            areAttachmentsEnabled: entity.isAttachmentsEnabled
+        )
+    }
+}

--- a/Sources/Domain/Model/ChatAlertType.swift
+++ b/Sources/Domain/Model/ChatAlertType.swift
@@ -102,4 +102,12 @@ final class ChatAlertType: Identifiable {
             secondary: .cancel()
         )
     }
+    
+    static func downloadFailed(localization: ChatLocalization) -> ChatAlertType? {
+        ChatAlertType(
+            title: localization.commonAttention, 
+            message: localization.chatAttachmentsDownloadFailed,
+            primary: .cancel()
+        )
+    }
 }

--- a/Sources/Domain/Model/CustomFields/ListFieldEntity.swift
+++ b/Sources/Domain/Model/CustomFields/ListFieldEntity.swift
@@ -38,6 +38,11 @@ public class ListFieldEntity: FormCustomFieldType {
     /// A dictionary that holds a set of options where the keys represent option values and the values represent option labels.
     public let options: [String: String]
 
+    /// The current value associated with the field
+    public var selectedOption: String {
+        options[value] ?? ""
+    }
+    
     // MARK: - Init
 
     /// Initialization of the ListFieldEntity

--- a/Sources/Domain/Model/CustomFields/TreeNodeFieldEntity.swift
+++ b/Sources/Domain/Model/CustomFields/TreeNodeFieldEntity.swift
@@ -55,6 +55,9 @@ public class TreeNodeFieldEntity: ObservableObject, Identifiable {
     
     // MARK: - Properties
     
+    /// The unique identifier of the tree node.
+    public let id: UUID
+    
     /// The label or name associated with the tree node.
     public let label: String
     
@@ -62,7 +65,7 @@ public class TreeNodeFieldEntity: ObservableObject, Identifiable {
     public let value: String
     
     /// An array of `TreeNodeFieldEntity` objects, representing child nodes within the tree.
-    public let children: [TreeNodeFieldEntity]
+    public let children: [TreeNodeFieldEntity]?
     
     /// A boolean flag indicating whether the tree node is currently selected.
     public var isSelected: Bool
@@ -75,7 +78,8 @@ public class TreeNodeFieldEntity: ObservableObject, Identifiable {
     /// - `value`: The value or unique identifier of the tree node.
     /// - `children`: An array of `TreeNodeFieldEntity` objects, representing child nodes within the tree.
     /// - `isSelected`: A boolean flag indicating whether the tree node is currently selected.
-    public init(label: String, value: String, children: [TreeNodeFieldEntity] = [], isSelected: Bool = false) {
+    public init(id: UUID = UUID(), label: String, value: String, children: [TreeNodeFieldEntity]? = nil, isSelected: Bool = false) {
+        self.id = id
         self.label = label
         self.value = value
         self.children = children
@@ -87,13 +91,13 @@ public class TreeNodeFieldEntity: ObservableObject, Identifiable {
 
 extension [TreeNodeFieldEntity] {
     
-    func find(by value: String) -> TreeNodeFieldEntity? {
+    func find(with value: String) -> TreeNodeFieldEntity? {
         for node in self {
             if node.value == value {
                 return node
             }
             
-            if let match = node.children.find(by: value) {
+            if let match = node.children?.find(with: value) {
                 return match
             }
         }

--- a/Sources/Domain/Model/Mappers/FormCustomFieldTypeMapper.swift
+++ b/Sources/Domain/Model/Mappers/FormCustomFieldTypeMapper.swift
@@ -18,19 +18,31 @@ import Foundation
 
 enum FormCustomFieldTypeMapper {
     
-    static func map(_ customField: PreChatSurveyCustomField) -> FormCustomFieldType {
+    static func map(_ customField: PreChatSurveyCustomField, with customFieldValues: [String: String]) -> FormCustomFieldType {
         switch customField.type {
         case .textField(let entity):
-            return TextFieldEntity(label: entity.label, isRequired: customField.isRequired, ident: entity.ident, isEmail: entity.isEmail, value: entity.value)
+            return TextFieldEntity(
+                label: entity.label,
+                isRequired: customField.isRequired,
+                ident: entity.ident,
+                isEmail: entity.isEmail,
+                value: customFieldValues[entity.ident]
+            )
         case .selector(let entity):
-            return ListFieldEntity(label: entity.label, isRequired: customField.isRequired, ident: entity.ident, options: entity.options, value: entity.value)
+            return ListFieldEntity(
+                label: entity.label,
+                isRequired: customField.isRequired,
+                ident: entity.ident,
+                options: entity.options,
+                value: customFieldValues[entity.ident]
+            )
         case .hierarchical(let entity):
             return TreeFieldEntity(
                 label: entity.label,
                 isRequired: customField.isRequired,
                 ident: entity.ident,
                 children: entity.nodes.map(mapChild),
-                value: entity.value
+                value: customFieldValues[entity.ident]
             )
         }
     }

--- a/Sources/Presentation/Example/ChatExampleView.swift
+++ b/Sources/Presentation/Example/ChatExampleView.swift
@@ -26,6 +26,12 @@ public struct ChatExampleView: View {
 
     @ObservedObject private var viewModel: ChatExampleViewModel
     
+    private static let attachmentRestrictions = AttachmentRestrictions(
+        allowedFileSize: 40,
+        allowedTypes: ["image/*", "video/*", "audio/*"],
+        areAttachmentsEnabled: true
+    )
+    
     // MARK: - Init
     
     /// Initialization of the ChatExampleView
@@ -42,7 +48,9 @@ public struct ChatExampleView: View {
             isAgentTyping: $viewModel.isAgentTyping,
             isUserTyping: $viewModel.isUserTyping,
             isInputEnabled: $viewModel.isInputEnabled,
+            isProcessDialogVisible: $viewModel.isProcessDialogVisible,
             alertType: $viewModel.alertType,
+            attachmentRestrictions: Self.attachmentRestrictions,
             onNewMessage: viewModel.onNewMessage,
             onPullToRefresh: viewModel.onPullToRefresh, 
             onRichMessageElementSelected: viewModel.onRichMessageElementSelected

--- a/Sources/Presentation/Example/ChatExampleViewModel.swift
+++ b/Sources/Presentation/Example/ChatExampleViewModel.swift
@@ -24,6 +24,7 @@ class ChatExampleViewModel: ObservableObject {
     @Published var isAgentTyping = false
     @Published var isUserTyping = false
     @Published var isInputEnabled = true
+    @Published var isProcessDialogVisible = false
     @Published var alertType: ChatAlertType?
     
     let isChatHistoryEnabled: Bool
@@ -39,15 +40,25 @@ class ChatExampleViewModel: ObservableObject {
                 MockData.textMessage(),
                 MockData.imageMessage(),
                 MockData.emojiMessage(),
+                MockData.hyperlinkMessage(),
                 MockData.textMessage(),
                 MockData.emojiMessage(),
                 MockData.textMessage(),
+                MockData.phoneNumberMessage(),
                 MockData.textMessage()
             ])
         }
     }
     
     func onNewMessage(messageType: ChatMessageType, attachments: [AttachmentItem]) {
+        if !attachments.isEmpty {
+            isProcessDialogVisible = true
+            
+            DispatchQueue.main.asyncAfter(deadline: .now() + 1) { [weak self] in
+                self?.isProcessDialogVisible = false
+            }
+        }
+        
         switch messageType {
         case .text(let text):
             if !text.isEmpty {

--- a/Sources/Presentation/Example/MockData.swift
+++ b/Sources/Presentation/Example/MockData.swift
@@ -20,6 +20,12 @@ enum MockData {
     
     // MARK: - Properties
     
+    static var hyperlinkContent: String {
+        Lorem.words(nbWords: Int.random(in: 0..<5)) + " \(imageUrl.absoluteString) " + Lorem.words(nbWords: Int.random(in: 0..<5))
+    }
+    static var phoneNumberContent: String {
+        Lorem.words(nbWords: Int.random(in: 0..<5)) + " (123) 456-7890 " + Lorem.words(nbWords: Int.random(in: 0..<5))
+    }
     static var imageUrl: URL {
         URL(string: "https://picsum.photos/id/\(Int.random(in: 1...700))/300/300").unsafelyUnwrapped
     }
@@ -58,6 +64,26 @@ enum MockData {
             id: UUID(),
             user: user ?? [customer, agent].random().unsafelyUnwrapped,
             types: [.text(Lorem.sentence())],
+            date: date,
+            status: .seen
+        )
+    }
+    
+    static func hyperlinkMessage(user: ChatUser? = nil, date: Date = Date()) -> ChatMessage {
+        ChatMessage(
+            id: UUID(),
+            user: user ?? [customer, agent].random().unsafelyUnwrapped,
+            types: [.text(hyperlinkContent)],
+            date: date,
+            status: .seen
+        )
+    }
+    
+    static func phoneNumberMessage(user: ChatUser? = nil, date: Date = Date()) -> ChatMessage {
+        ChatMessage(
+            id: UUID(),
+            user: user ?? [customer, agent].random().unsafelyUnwrapped,
+            types: [.text(phoneNumberContent)],
             date: date,
             status: .seen
         )

--- a/Sources/Presentation/Implementation/Default/Chat/DefaultChatView.swift
+++ b/Sources/Presentation/Implementation/Default/Chat/DefaultChatView.swift
@@ -61,7 +61,9 @@ struct DefaultChatView: Alertable, View {
                     isAgentTyping: $viewModel.isAgentTyping,
                     isUserTyping: $viewModel.isUserTyping,
                     isInputEnabled: $viewModel.isInputEnabled,
+                    isProcessDialogVisible: $viewModel.isProcessDialogVisible,
                     alertType: $viewModel.alertType,
+                    attachmentRestrictions: viewModel.attachmentRestrictions,
                     onNewMessage: { messageType, attachments in
                         viewModel.onSendMessage(messageType, attachments: attachments)
                     },
@@ -120,7 +122,6 @@ private extension DefaultChatView {
             onBackToConversationTapped: viewModel.onEndConversationBackTapped,
             onCloseChatTapped: viewModel.onEndConversationCloseTapped
         )
-        .ignoresSafeArea()
     }
     
     var toolbarTrailingMenu: some View {

--- a/Sources/Presentation/Implementation/Default/Coordinator/DefaultChatCoordinatorViewModel.swift
+++ b/Sources/Presentation/Implementation/Default/Coordinator/DefaultChatCoordinatorViewModel.swift
@@ -90,7 +90,9 @@ extension DefaultChatCoordinatorViewModel: CXoneChatDelegate {
                     let chatMode = mode == .liveChat ? ".liveChat" : ".singlethread"
                     LogManager.trace("Chat(\(chatMode)) is ready to use but there is no thread to use but firstly it is need to fill in the prechat")
                     
-                    let fieldEntities = preChatSurvey.customFields.map(FormCustomFieldTypeMapper.map)
+                    let fieldEntities = preChatSurvey.customFields.map { prechatField in
+                        FormCustomFieldTypeMapper.map(prechatField, with: [:])
+                    }
 
                     coordinator.presentForm(
                         title: preChatSurvey.name,

--- a/Sources/Presentation/Implementation/Default/List/DefaultChatListViewModel.swift
+++ b/Sources/Presentation/Implementation/Default/List/DefaultChatListViewModel.swift
@@ -89,7 +89,9 @@ extension DefaultChatListViewModel {
         LogManager.trace("Trying to create a new thread")
 
         if let preChatSurvey = CXoneChat.shared.threads.preChatSurvey {
-            let fieldEntities = preChatSurvey.customFields.map(FormCustomFieldTypeMapper.map)
+            let fieldEntities = preChatSurvey.customFields.map { prechatField in
+                FormCustomFieldTypeMapper.map(prechatField, with: [:])
+            }
             
             coordinator.presentForm(title: preChatSurvey.name, customFields: fieldEntities) { customFields in
                 Task { @MainActor in
@@ -216,7 +218,11 @@ extension DefaultChatListViewModel: CXoneChatDelegate {
     func onTokenRefreshFailed() {
         LogManager.trace("Token refresh failed")
         
-        CXoneChat.shared.customer.set(nil)
+        do {
+            try CXoneChat.shared.customer.set(nil)
+        } catch {
+            error.logError()
+        }
 
         coordinator.dismiss(animated: true)
     }

--- a/Sources/Resources/en.lproj/CXOneChatUI.strings
+++ b/Sources/Resources/en.lproj/CXOneChatUI.strings
@@ -62,6 +62,8 @@
 "chatui_chat_attachments_deselect" = "None";
 "chatui_chat_attachments_selectionMode" = "Select items";
 "chatui_chat_attachments_selectedCount_message" = "%1$d item(s) selected";
+"chatui_chat_attachments_upload" = "Sending...";
+"chatui_chat_attachments_download_failed" = "The document could not be downloaded at this time. Please check your internet connection and try again.";
 
 // Chat - Menu Actions
 "chatui_chat_menuOption_disconnect" = "Disconnect";

--- a/Sources/UI/Extensions/View/View+Extensions.swift
+++ b/Sources/UI/Extensions/View/View+Extensions.swift
@@ -53,7 +53,13 @@ extension View {
             self
             
             if isVisible.wrappedValue {
+                Color(.darkGray)
+                    .opacity(0.5)
+                    .ignoresSafeArea()
+                
                 overlayContent()
+                    .compositingGroup()
+                    .shadow(color: .gray, radius: 4)
             }
         }
     }

--- a/Sources/UI/Extensions/View/View+MessageChatTextStyle.swift
+++ b/Sources/UI/Extensions/View/View+MessageChatTextStyle.swift
@@ -60,6 +60,7 @@ private struct ChatTextStyleModifier: ViewModifier {
             .font(font)
             .background(background)
             .foregroundColor(message.user.isAgent ? style.agentFontColor : style.customerFontColor)
+            .tint(message.user.isAgent ? style.agentFontColor : style.customerFontColor)
             .cornerRadius(topLeftCornerRadius, corners: .topLeft)
             .cornerRadius(topRightCornerRadius, corners: .topRight)
             .cornerRadius(bottomLeftCornerRadius, corners: .bottomLeft)

--- a/Sources/UI/Extensions/View/View+Refreshable.swift
+++ b/Sources/UI/Extensions/View/View+Refreshable.swift
@@ -61,7 +61,7 @@ private struct OnListRefreshModifier: ViewModifier {
     
     func body(content: Content) -> some View {
         content
-            .introspect(.scrollView, on: .iOS(.v14, .v15, .v16, .v17), scope: .ancestor) { scrollView in
+            .introspect(.scrollView, on: .iOS(.v15, .v16, .v17), scope: .ancestor) { scrollView in
                 scrollView.onRefresh(onValueChanged)
             }
     }

--- a/Sources/UI/Form/FormViewModel.swift
+++ b/Sources/UI/Form/FormViewModel.swift
@@ -22,8 +22,6 @@ class FormViewModel: ObservableObject {
     
     @Published var customFields: [FormCustomFieldType]
     
-    var nodeSelected: TreeFieldEntity?
-    
     // MARK: - Init
 
     init(customFields: [FormCustomFieldType]) {
@@ -39,10 +37,6 @@ extension FormViewModel {
         self.customFields.allSatisfy { type in
             type.isRequired ? !type.value.isEmpty : true
         }
-    }
-    
-    func updateView() {
-        self.objectWillChange.send()
     }
 
     func getCustomFields() -> [String: String] {

--- a/Sources/UI/Form/Subviews/ListFieldView.swift
+++ b/Sources/UI/Form/Subviews/ListFieldView.swift
@@ -36,7 +36,7 @@ struct ListFieldView: View {
                     .foregroundColor(style.formTextColor)
                 
                 HStack(spacing: 4) {
-                    Button(entity.value.isEmpty ? localization.commonNoSelection : entity.value) {
+                    Button(entity.value.isEmpty ? localization.commonNoSelection : entity.selectedOption) {
                         isActionSheetVisible.toggle()
                     }
                     
@@ -57,7 +57,7 @@ struct ListFieldView: View {
         }
         .actionSheet(isPresented: $isActionSheetVisible) {
             var options: [ActionSheet.Button] = entity.options.map { option in
-                    .default(Text(option.value)) { entity.value = option.value }
+                .default(Text(option.value)) { entity.value = option.key }
             }
             options.append(.cancel { entity.value = "" })
 
@@ -71,7 +71,13 @@ struct ListFieldView: View {
 
 struct ListFieldView_Previews: PreviewProvider {
 
-    private static let entity = ListFieldEntity(label: "Color", isRequired: true, ident: "color", options: ["blue": "Blue", "yellow": "Yellow"])
+    private static let entity = ListFieldEntity(
+        label: "Color",
+        isRequired: true,
+        ident: "color",
+        options: ["blue": "Blue", "yellow": "Yellow"],
+        value: "yellow"
+    )
 
     static var previews: some View {
         Group {

--- a/Sources/UI/Views/ChatMessageCell.swift
+++ b/Sources/UI/Views/ChatMessageCell.swift
@@ -21,6 +21,9 @@ struct ChatMessageCell: View {
 
     @EnvironmentObject private var style: ChatStyle
 
+    @Binding private var isProcessDialogVisible: Bool
+    @Binding private var alertType: ChatAlertType?
+    
     @State private var forceDateHeader = false
 
     private let message: ChatMessage
@@ -33,10 +36,14 @@ struct ChatMessageCell: View {
     init(
         message: ChatMessage,
         messageGroupPosition: MessageGroupPosition,
+        isProcessDialogVisible: Binding<Bool>,
+        alertType: Binding<ChatAlertType?>,
         onRichMessageElementTapped: @escaping (_ textToSend: String?, RichMessageSubElementType) -> Void
     ) {
         self.message = message
         self.messageGroupPosition = messageGroupPosition
+        self._isProcessDialogVisible = isProcessDialogVisible
+        self._alertType = alertType
         self.onRichMessageElementTapped = onRichMessageElementTapped
         self.isMultiAttachment = message.types.filter(\.isAttachment).count > 1
     }
@@ -76,11 +83,7 @@ private extension ChatMessageCell {
             case .audio(let item):
                 AudioMessageCell(message: message, item: item, isMultiAttachment: false, position: messageGroupPosition)
             case .linkPreview(let item):
-                LinkPreviewCell(message: message, item: item) { url in
-                    if UIApplication.shared.canOpenURL(url) {
-                        UIApplication.shared.open(url)
-                    }
-                }
+                LinkPreviewCell(message: message, item: item, isProcessDialogVisible: $isProcessDialogVisible, alertType: $alertType)
             case .richContent(let content):
                 switch content {
                 case .quickReplies(let item):
@@ -130,24 +133,64 @@ struct DefaultMessageItemPreview: PreviewProvider {
     static var previews: some View {
         Group {
             LazyVStack {
-                ChatMessageCell(message: agentImageMessage, messageGroupPosition: .first) { _, _ in }
+                ChatMessageCell(
+                    message: agentImageMessage,
+                    messageGroupPosition: .first,
+                    isProcessDialogVisible: .constant(false),
+                    alertType: .constant(nil)
+                ) { _, _ in }
                 
-                ChatMessageCell(message: agentTextMessage, messageGroupPosition: .last) { _, _ in }
+                ChatMessageCell(
+                    message: agentTextMessage,
+                    messageGroupPosition: .last,
+                    isProcessDialogVisible: .constant(false),
+                    alertType: .constant(nil)
+                ) { _, _ in }
 
-                ChatMessageCell(message: customerAudioMessage, messageGroupPosition: .first) { _, _ in }
+                ChatMessageCell(
+                    message: customerAudioMessage,
+                    messageGroupPosition: .first,
+                    isProcessDialogVisible: .constant(false),
+                    alertType: .constant(nil)
+                ) { _, _ in }
                 
-                ChatMessageCell(message: customerImageMessage, messageGroupPosition: .last) { _, _ in }
+                ChatMessageCell(
+                    message: customerImageMessage,
+                    messageGroupPosition: .last,
+                    isProcessDialogVisible: .constant(false),
+                    alertType: .constant(nil)
+                ) { _, _ in }
             }
             .previewDisplayName("Light mode")
             
             LazyVStack {
-                ChatMessageCell(message: agentImageMessage, messageGroupPosition: .first) { _, _ in }
+                ChatMessageCell(
+                    message: agentImageMessage,
+                    messageGroupPosition: .first,
+                    isProcessDialogVisible: .constant(false),
+                    alertType: .constant(nil)
+                ) { _, _ in }
                 
-                ChatMessageCell(message: agentTextMessage, messageGroupPosition: .last) { _, _ in }
+                ChatMessageCell(
+                    message: agentTextMessage,
+                    messageGroupPosition: .last,
+                    isProcessDialogVisible: .constant(false),
+                    alertType: .constant(nil)
+                ) { _, _ in }
 
-                ChatMessageCell(message: customerAudioMessage, messageGroupPosition: .first) { _, _ in }
+                ChatMessageCell(
+                    message: customerAudioMessage,
+                    messageGroupPosition: .first,
+                    isProcessDialogVisible: .constant(false),
+                    alertType: .constant(nil)
+                ) { _, _ in }
                 
-                ChatMessageCell(message: customerImageMessage, messageGroupPosition: .last) { _, _ in }
+                ChatMessageCell(
+                    message: customerImageMessage,
+                    messageGroupPosition: .last,
+                    isProcessDialogVisible: .constant(false),
+                    alertType: .constant(nil)
+                ) { _, _ in }
             }
             .preferredColorScheme(.dark)
             .previewDisplayName("Dark mode")

--- a/Sources/UI/Views/ChatMessageCellType/QuickLookPreview.swift
+++ b/Sources/UI/Views/ChatMessageCellType/QuickLookPreview.swift
@@ -1,0 +1,81 @@
+//
+// Copyright (c) 2021-2024. NICE Ltd. All rights reserved.
+//
+// Licensed under the NICE License;
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    https://github.com/nice-devone/nice-cxone-mobile-ui-ios/blob/main/LICENSE
+//
+// TO THE EXTENT PERMITTED BY APPLICABLE LAW, THE CXONE MOBILE SDK IS PROVIDED ON
+// AN “AS IS” BASIS. NICE HEREBY DISCLAIMS ALL WARRANTIES AND CONDITIONS, EXPRESS
+// OR IMPLIED, INCLUDING (WITHOUT LIMITATION) WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, AND TITLE.
+//
+
+import QuickLook
+import SwiftUI
+
+struct QuickLookPreview: UIViewControllerRepresentable {
+    
+    // MARK: - Properties
+    
+    var url: URL
+    
+    @Binding var isPresented: Bool
+    
+    // MARK: - Methods
+    
+    func makeUIViewController(context: Context) -> some UIViewController {
+        let previewController = QLPreviewController()
+        previewController.dataSource = context.coordinator
+
+        let navigationController = UINavigationController(rootViewController: previewController)
+
+        previewController.navigationItem.rightBarButtonItem = UIBarButtonItem(
+            barButtonSystemItem: .done,
+            target: context.coordinator,
+            action: #selector(context.coordinator.dismissPreviewController)
+        )
+
+        return navigationController
+    }
+    
+    func updateUIViewController(_ uiViewController: UIViewControllerType, context: Context) {
+        // update if needed
+    }
+    
+    func makeCoordinator() -> Coordinator {
+        Coordinator(parent: self, url: url, isPresented: $isPresented)
+    }
+    
+    // MARK: - Coordinator
+    
+    class Coordinator: NSObject, QLPreviewControllerDataSource {
+        var parent: QuickLookPreview
+        var url: URL
+        @Binding var isPresented: Bool
+        
+        // MARK: - Init
+        
+        init(parent: QuickLookPreview, url: URL, isPresented: Binding<Bool>) {
+            self.parent = parent
+            self.url = url
+            self._isPresented = isPresented
+        }
+        
+        // MARK: - Methods
+        
+        func numberOfPreviewItems(in controller: QLPreviewController) -> Int {
+            1
+        }
+        
+        func previewController(_ controller: QLPreviewController, previewItemAt index: Int) -> any QLPreviewItem {
+            url as QLPreviewItem
+        }
+        
+        @objc func dismissPreviewController() {
+            self._isPresented.wrappedValue = false
+        }
+    }
+}

--- a/Sources/UI/Views/DocumentPickerView.swift
+++ b/Sources/UI/Views/DocumentPickerView.swift
@@ -23,6 +23,8 @@ struct DocumentPickerView: UIViewControllerRepresentable {
     
     @SwiftUI.Environment(\.presentationMode) var presentationMode
     
+    let attachmentRestrictions: AttachmentRestrictions
+    
     var onSelected: ([AttachmentItem]) -> Void
 
     // MARK: - Methods
@@ -32,7 +34,7 @@ struct DocumentPickerView: UIViewControllerRepresentable {
     }
 
     func makeUIViewController(context: Context) -> UIDocumentPickerViewController {
-        let validContentTypes = UTType.resolve(for: CXoneChat.shared.connection.channelConfiguration.fileRestrictions.allowedFileTypes)
+        let validContentTypes = UTType.resolve(for: attachmentRestrictions.allowedTypes)
         
         let documentPicker = UIDocumentPickerViewController(forOpeningContentTypes: validContentTypes)
         documentPicker.delegate = context.coordinator

--- a/Sources/UI/Views/EndConversationView.swift
+++ b/Sources/UI/Views/EndConversationView.swift
@@ -45,68 +45,61 @@ struct EndConversationView: View {
     // MARK: - Builder
     
     var body: some View {
-        ZStack {
-            Color(.darkGray)
-                .opacity(0.5)
-            
-            VStack(spacing: 0) {
-                if let agentName {
-                    MessageAvatarView(avatarUrl: agentAvatarUrl, initials: agentNameInitials)
-                        .frame(width: 80, height: 80, alignment: .center)
-                        .shadow(radius: 4, x: 2, y: 2)
-                        .padding(.bottom, 12)
-                    
-                    Text(localization.liveChatEndConversationAssignedAgent)
-                        .foregroundColor(style.formTextColor)
-                    
-                    Text(agentName)
-                        .font(.title)
-                        .bold()
-                        .foregroundColor(style.formTextColor)
-                        .multilineTextAlignment(.center)
-                        .padding(.horizontal, 12)
-                        .padding(.bottom, 24)
-                }
+        VStack(spacing: 0) {
+            if let agentName {
+                MessageAvatarView(avatarUrl: agentAvatarUrl, initials: agentNameInitials)
+                    .frame(width: 80, height: 80, alignment: .center)
+                    .shadow(radius: 4, x: 2, y: 2)
+                    .padding(.bottom, 12)
                 
-                VStack {
-                    Button(action: onStartNewTapped) {
-                        HStack {
-                            Asset.LiveChat.newChat
-                            
-                            Text(localization.liveChatEndConversationNew)
-                        }
-                    }
-                    .buttonStyle(PrimaryButtonStyle(chatStyle: style))
-                    
-                    Button(action: onBackToConversationTapped) {
-                        HStack {
-                            Asset.back
-                            
-                            Text(localization.liveChatEndConversationBack)
-                        }
-                    }
-                    .buttonStyle(PrimaryButtonStyle(chatStyle: style))
-                    
-                    Button(action: onCloseChatTapped) {
-                        HStack {
-                            Asset.disconnect
-                            
-                            Text(localization.liveChatEndConversationClose)
-                        }
-                    }
-                    .buttonStyle(PrimaryButtonStyle(chatStyle: style))
-                }
-                .padding(.horizontal, 24)
+                Text(localization.liveChatEndConversationAssignedAgent)
+                    .foregroundColor(style.formTextColor)
+                
+                Text(agentName)
+                    .font(.title)
+                    .bold()
+                    .foregroundColor(style.formTextColor)
+                    .multilineTextAlignment(.center)
+                    .padding(.horizontal, 12)
+                    .padding(.bottom, 24)
             }
-            .padding(.vertical, 20)
-            .background(
-                RoundedRectangle(cornerRadius: 24)
-                    .fill(style.backgroundColor)
-            )
-            .compositingGroup()
-            .shadow(radius: 4, x: 2, y: 2)
-            .padding(.horizontal, 40)
+            
+            VStack {
+                Button(action: onStartNewTapped) {
+                    HStack {
+                        Asset.LiveChat.newChat
+                        
+                        Text(localization.liveChatEndConversationNew)
+                    }
+                }
+                .buttonStyle(PrimaryButtonStyle(chatStyle: style))
+                
+                Button(action: onBackToConversationTapped) {
+                    HStack {
+                        Asset.back
+                        
+                        Text(localization.liveChatEndConversationBack)
+                    }
+                }
+                .buttonStyle(PrimaryButtonStyle(chatStyle: style))
+                
+                Button(action: onCloseChatTapped) {
+                    HStack {
+                        Asset.disconnect
+                        
+                        Text(localization.liveChatEndConversationClose)
+                    }
+                }
+                .buttonStyle(PrimaryButtonStyle(chatStyle: style))
+            }
+            .padding(.horizontal, 24)
         }
+        .padding(.vertical, 20)
+        .background(
+            RoundedRectangle(cornerRadius: 24)
+                .fill(style.backgroundColor)
+        )
+        .padding(.horizontal, 40)
     }
 }
 
@@ -116,42 +109,56 @@ struct EndConversationView_Previews: PreviewProvider {
 
     // MARK: - Properties
 
+    private static let isOverlayVisible: Binding<Bool> = .constant(true)
+    // MARK: - Previews
+    
     static var previews: some View {
         Group {
             ChatExampleView(withHistory: true)
-                .overlay(getEndConversationView(agentAvatarUrl: MockData.agent.avatarURL, agentName: MockData.agent.userName), alignment: .center)
+                .overlay(isVisible: isOverlayVisible) {
+                    getEndConversationView(agentAvatarUrl: MockData.agent.avatarURL, agentName: MockData.agent.userName)
+                }
                 .environmentObject(ChatStyle(formTextColor: Color(.darkText)))
                 .previewDisplayName("Agent with image - Light Mode")
             
             ChatExampleView(withHistory: true)
-                .overlay(getEndConversationView(agentAvatarUrl: MockData.agent.avatarURL, agentName: MockData.agent.userName), alignment: .center)
+                .overlay(isVisible: isOverlayVisible) {
+                    getEndConversationView(agentAvatarUrl: MockData.agent.avatarURL, agentName: MockData.agent.userName)
+                }
                 .environmentObject(ChatStyle(formTextColor: Color(.lightText)))
                 .preferredColorScheme(.dark)
                 .previewDisplayName("Agent with image - Dark Mode")
             
             ChatExampleView(withHistory: true)
-                .overlay(getEndConversationView(agentName: MockData.agent.userName), alignment: .center)
+                .overlay(isVisible: isOverlayVisible) {
+                    getEndConversationView(agentName: MockData.agent.userName)
+                }
                 .environmentObject(ChatStyle(formTextColor: Color(.darkText)))
                 .previewDisplayName("Agent without image - Light Mode")
             
             ChatExampleView(withHistory: true)
-                .overlay(getEndConversationView(agentName: MockData.agent.userName), alignment: .center)
+                .overlay(isVisible: isOverlayVisible) {
+                    getEndConversationView(agentName: MockData.agent.userName)
+                }
                 .environmentObject(ChatStyle(formTextColor: Color(.lightText)))
                 .preferredColorScheme(.dark)
                 .previewDisplayName("Agent without image - Dark Mode")
             
             ChatExampleView(withHistory: true)
-                .overlay(getEndConversationView(), alignment: .center)
+                .overlay(isVisible: isOverlayVisible) {
+                    getEndConversationView()
+                }
                 .environmentObject(ChatStyle(formTextColor: Color(.darkText)))
                 .previewDisplayName("Agent without name - Light Mode")
             
             ChatExampleView(withHistory: true)
-                .overlay(getEndConversationView(), alignment: .center)
+                .overlay(isVisible: isOverlayVisible) {
+                    getEndConversationView()
+                }
                 .environmentObject(ChatStyle(formTextColor: Color(.lightText)))
                 .preferredColorScheme(.dark)
                 .previewDisplayName("Agent without name - Dark Mode")
         }
-        .ignoresSafeArea()
         .environmentObject(ChatLocalization())
     }
     

--- a/Sources/UI/Views/MediaPickerView.swift
+++ b/Sources/UI/Views/MediaPickerView.swift
@@ -24,6 +24,8 @@ struct MediaPickerView: UIViewControllerRepresentable {
     
     @SwiftUI.Environment(\.presentationMode) var presentationMode
     
+    let attachmentRestrictions: AttachmentRestrictions
+    
     var sourceType: UIImagePickerController.SourceType = .photoLibrary
     var onSelected: (AttachmentItem) -> Void
     
@@ -34,7 +36,7 @@ struct MediaPickerView: UIViewControllerRepresentable {
     }
     
     func makeUIViewController(context: UIViewControllerRepresentableContext<MediaPickerView>) -> UIImagePickerController {
-        let validContentTypes = UTType.resolve(for: CXoneChat.shared.connection.channelConfiguration.fileRestrictions.allowedFileTypes)
+        let validContentTypes = UTType.resolve(for: attachmentRestrictions.allowedTypes)
         
         let picker = UIImagePickerController()
         picker.delegate = context.coordinator

--- a/Sources/UI/Views/MessageGroupView.swift
+++ b/Sources/UI/Views/MessageGroupView.swift
@@ -19,12 +19,29 @@ import SwiftUI
 struct MessageGroupView: View {
 
     // MARK: - Properties
-    
+
     @EnvironmentObject private var style: ChatStyle
+    
+    @Binding private var isProcessDialogVisible: Bool
+    @Binding private var alertType: ChatAlertType?
 
     @State var group: MessageGroup
 
     let onRichMessageElementSelected: (_ textToSend: String?, RichMessageSubElementType) -> Void
+    
+    // MARK: - Init
+    
+    init(
+        group: MessageGroup,
+        isProcessDialogVisible: Binding<Bool>,
+        alertType: Binding<ChatAlertType?>,
+        onRichMessageElementSelected: @escaping (_: String?, RichMessageSubElementType) -> Void
+    ) {
+        self.group = group
+        self._isProcessDialogVisible = isProcessDialogVisible
+        self._alertType = alertType
+        self.onRichMessageElementSelected = onRichMessageElementSelected
+    }
 
     // MARK: - Builder
     
@@ -38,6 +55,8 @@ struct MessageGroupView: View {
                         ChatMessageCell(
                             message: message,
                             messageGroupPosition: group.position(of: message),
+                            isProcessDialogVisible: $isProcessDialogVisible,
+                            alertType: $alertType,
                             onRichMessageElementTapped: onRichMessageElementSelected
                         )
                     }
@@ -65,7 +84,7 @@ extension MessageGroupView {
 
     var header: some View {
         Group {
-            Text(group.date.formatted())
+            Text(group.date.formatted(format: "MMM d, yyyy"))
                 .font(.footnote.bold())
                 .foregroundColor(style.formTextColor.opacity(0.5))
                 .frame(maxWidth: .infinity)
@@ -145,7 +164,7 @@ struct MessageGroupView_Previews: PreviewProvider {
         ScrollView {
             VStack {
                 ForEach(manager.groupMessages()) { message in
-                    MessageGroupView(group: message) { _, _ in }
+                    MessageGroupView(group: message, isProcessDialogVisible: .constant(false), alertType: .constant(nil)) { _, _ in }
                 }
             }
         }

--- a/Sources/UI/Views/MessageInputView/Subviews/AttachmentListView.swift
+++ b/Sources/UI/Views/MessageInputView/Subviews/AttachmentListView.swift
@@ -36,13 +36,8 @@ struct AttachmentListView: View {
                     
                     ForEach(0..<attachments.count, id: \.self) { index in
                         ZStack(alignment: .topTrailing) {
-                            Asset.Attachment.file
-                                .padding(14)
-                                .background(
-                                    RoundedRectangle(cornerRadius: 10)
-                                        .fill(style.formTextColor.opacity(0.5))
-                                )
-                            
+                            thumbnailPreview(for: attachments[index])
+
                             Button {
                                 withAnimation {
                                     _ = attachments.remove(at: index)
@@ -65,5 +60,28 @@ struct AttachmentListView: View {
             }
             .frame(height: 60)
         }
+    }
+    
+    @ViewBuilder
+    private func thumbnailPreview(for attachment: AttachmentItem) -> some View {
+        if attachment.mimeType.starts(with: "image/"), let uiImage = imageFromURL(attachment.url) {
+            Image(uiImage: uiImage)
+                .resizable()
+                .clipShape(RoundedRectangle(cornerRadius: 10))
+                .frame(width: 50, height: 50)
+        } else if attachment.mimeType.starts(with: "video/") {
+            VideoThumbnailView(videoURL: attachment.url)
+        } else {
+            Asset.Attachment.file
+                .padding(14)
+                .background(RoundedRectangle(cornerRadius: 10).fill(style.formTextColor.opacity(0.5)))
+        }
+    }
+    
+    private func imageFromURL(_ url: URL) -> UIImage? {
+        guard let imageData = try? Data(contentsOf: url) else {
+            return nil
+        }
+        return UIImage(data: imageData)
     }
 }

--- a/Sources/UI/Views/MessageInputView/VideoThumbnailView.swift
+++ b/Sources/UI/Views/MessageInputView/VideoThumbnailView.swift
@@ -1,0 +1,48 @@
+//
+// Copyright (c) 2021-2024. NICE Ltd. All rights reserved.
+//
+// Licensed under the NICE License;
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    https://github.com/nice-devone/nice-cxone-mobile-ui-ios/blob/main/LICENSE
+//
+// TO THE EXTENT PERMITTED BY APPLICABLE LAW, THE CXONE MOBILE SDK IS PROVIDED ON
+// AN “AS IS” BASIS. NICE HEREBY DISCLAIMS ALL WARRANTIES AND CONDITIONS, EXPRESS
+// OR IMPLIED, INCLUDING (WITHOUT LIMITATION) WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, AND TITLE.
+//
+
+import SwiftUI
+
+struct VideoThumbnailView: View {
+    
+    // MARK: - Properties
+    
+    let videoURL: URL
+    private let width: CGFloat = 50
+    private let height: CGFloat = 50
+    private let cornerRadius: CGFloat = 8.0
+    
+    var body: some View {
+        ZStack {
+            thumbnail
+                .frame(width: width, height: height)
+                .cornerRadius(cornerRadius)
+            
+            Image(systemName: "video.fill")
+                .foregroundColor(.white)
+        }
+    }
+    
+    @ViewBuilder
+    private var thumbnail: some View {
+        if let thumbnailImage = videoURL.getVideoThumbnail(maximumSize: CGSize(width: width, height: height)) {
+            thumbnailImage
+                .resizable()
+        } else {
+            RoundedRectangle(cornerRadius: cornerRadius)
+                .fill(Color.gray)
+        }
+    }
+}

--- a/Sources/Utilities/ChatLocalization.swift
+++ b/Sources/Utilities/ChatLocalization.swift
@@ -140,6 +140,10 @@ public class ChatLocalization: ObservableObject {
     public lazy var chatAttachmentsSelectionMode = lookup(key: "chatui_chat_attachments_selectionMode")
     /// "%1$d item(s) selected"
     public lazy var chatAttachmentsSelectedCount = lookup(key: "chatui_chat_attachments_selectedCount_message")
+    /// "Processing..."
+    public lazy var chatAttachmentsUpload = lookup(key: "chatui_chat_attachments_upload")
+    /// "The document could not be downloaded at this time. Please check your internet connection and try again."
+    public lazy var chatAttachmentsDownloadFailed = lookup(key: "chatui_chat_attachments_download_failed")
     
     // MARK: - Chat - Menu Actions
     

--- a/Sources/Utilities/Extensions/UTType+Extensions.swift
+++ b/Sources/Utilities/Extensions/UTType+Extensions.swift
@@ -35,10 +35,10 @@ extension UTType {
         return UTType("public.\(contentType)")
     }
     
-    static func resolve(for allowedFileType: [AllowedFileType]) -> [UTType] {
-        var result = allowedFileType.compactMap { UTType.resolve(for: $0.mimeType) }
+    static func resolve(for allowedFileType: [String]) -> [UTType] {
+        var result = allowedFileType.compactMap(UTType.resolve)
         
-        if allowedFileType.contains(where: { $0.mimeType.contains(UTType.videoPreffix) }) {
+        if allowedFileType.contains(where: { $0.contains(UTType.videoPreffix) }) {
             result.append(UTType.movie)
         }
         


### PR DESCRIPTION
## 🏷 Description

### Features
- Attachments upload dialog
- Highlight text message cell content for links/phone numbers
- Update minimum iOS deployment target to 15
- Display thumbnail previews for selected attachment videos/images.
- Utilize Swift's Quicklook framework to view documents

### Bug Fixes
- Prefill prechat survey with customer data
- Rotation bug on iOS15
- Incorrect attachment size displayed for single attachment
- append UTType.movie for all videos
- fix MessageGroupView preview

### Dependencies
- Update CxoneChatSDK to 2.1.0

## 🛠 What's missing?

- None

## 📋 Checklist

- [x] Checks - Merge only when all tests passed and there are not SwiftLint warnings.
